### PR TITLE
Added a patch for high-rank pimps players.

### DIFF
--- a/Sunrise2/Sunrise2.cpp
+++ b/Sunrise2/Sunrise2.cpp
@@ -145,6 +145,11 @@ VOID Initialise()
 					Sunrise_Dbg("Halo 3 Pimps at sea (Alpha) detected! Initialising hooks...");
 					SetupNetDllHooks();
 
+					// Fix a bug where high rank players can't enter matchmaking.
+					*((DWORD*)(0x82457578)) = 0x3960000C;
+					// Fix another stats bug.
+					*((WORD*)(0x82454BAC)) = 0x4800;
+
 					// Enable debug logs.
 					*((DWORD*)(0x823b23d0)) = 0x60000000;
 					// Move them from cache:\\ to d:\\ 


### PR DESCRIPTION
Pimps at Sea has a bug where it reads the 4-bit max rank integer as signed, reducing it to 3 bits with a max value of 7.
This is a problem as players tend to exceed rank 7. The max should be 13.
To solve the issue I disregard whatever is read and set the max to 13. The max rank doesn't need to be configurable anyway- it's never been used to my knowledge (aside from basic training)